### PR TITLE
fix: set weights

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -100,11 +100,11 @@ class AgentValidator:
         self.scheduler_priority = int(os.getenv("SCHEDULER_PRIORITY", "100"))
 
         # Get network configuration from environment
-        network = os.getenv("SUBTENSOR_NETWORK", "finney")
-        network_address = os.getenv("SUBTENSOR_ADDRESS")
+        self.network = os.getenv("SUBTENSOR_NETWORK", "finney")
+        self.network_address = os.getenv("SUBTENSOR_ADDRESS")
 
         self.substrate = interface.get_substrate(
-            subtensor_network=network, subtensor_address=network_address
+            subtensor_network=self.network, subtensor_address=self.network_address
         )
         self.metagraph = Metagraph(netuid=self.netuid, substrate=self.substrate)
         self.metagraph.sync_nodes()
@@ -635,7 +635,8 @@ class AgentValidator:
         self.scored_posts = scored_posts
 
     async def set_weights(self):
-        self.substrate = interface.get_substrate(subtensor_address=self.substrate.url)
+        self.substrate = interface.get_substrate(subtensor_network=self.network)
+        # self.substrate = interface.get_substrate(subtensor_address=self.substrate.url)
         validator_node_id = self.substrate.query(
             "SubtensorModule", "Uids", [self.netuid, self.keypair.ss58_address]
         ).value

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -635,7 +635,6 @@ class AgentValidator:
         self.scored_posts = scored_posts
 
     async def set_weights(self):
-        # self.substrate = interface.get_substrate(subtensor_network=self.network)
         self.substrate = interface.get_substrate(subtensor_address=self.substrate.url)
         validator_node_id = self.substrate.query(
             "SubtensorModule", "Uids", [self.netuid, self.keypair.ss58_address]

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -643,19 +643,55 @@ class AgentValidator:
         version_key = self.substrate.query(
             "SubtensorModule", "WeightsVersionKey", [self.netuid]
         ).value
+
+        blocks_since_update = weights._blocks_since_last_update(
+            self.substrate, self.netuid, validator_node_id
+        )
+        min_interval = weights._min_interval_to_set_weights(self.substrate, self.netuid)
+
+        logger.info(f"Blocks since last update: {blocks_since_update}")
+        logger.info(f"Minimum interval required: {min_interval}")
+
+        if blocks_since_update is not None and blocks_since_update < min_interval:
+            wait_blocks = min_interval - blocks_since_update
+            logger.info(
+                f"Need to wait {
+                    wait_blocks} more blocks before setting weights"
+            )
+            # Assuming ~12 second block time
+            wait_seconds = wait_blocks * 12
+            logger.info(f"Waiting {wait_seconds} seconds...")
+            await asyncio.sleep(wait_seconds)
+
         uids, scores = self.get_average_score()
 
-        weights.set_node_weights(
-            substrate=self.substrate,
-            keypair=self.keypair,
-            node_ids=uids,
-            node_weights=scores,
-            netuid=self.netuid,
-            validator_node_id=validator_node_id,
-            version_key=version_key,
-            wait_for_inclusion=True,
-            wait_for_finalization=True,
-        )
+        # Set weights with multiple attempts
+        for attempt in range(3):
+            try:
+                success = weights.set_node_weights(
+                    substrate=self.substrate,
+                    keypair=self.keypair,
+                    node_ids=uids,
+                    node_weights=scores,
+                    netuid=self.netuid,
+                    validator_node_id=validator_node_id,
+                    version_key=version_key,
+                    wait_for_inclusion=True,
+                    wait_for_finalization=True,
+                )
+
+                if success:
+                    logger.info("✅ Successfully set weights!")
+                    return
+                else:
+                    logger.error(f"❌ Failed to set weights on attempt {attempt + 1}")
+                    await asyncio.sleep(10)  # Wait between attempts
+
+            except Exception as e:
+                logger.error(f"Error on attempt {attempt + 1}: {str(e)}")
+                await asyncio.sleep(10)  # Wait between attempts
+
+        logger.error("Failed to set weights after all attempts")
 
     def get_average_score(self):
         uids = list(set([int(post["uid"]) for post in self.scored_posts]))

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -635,8 +635,8 @@ class AgentValidator:
         self.scored_posts = scored_posts
 
     async def set_weights(self):
-        self.substrate = interface.get_substrate(subtensor_network=self.network)
-        # self.substrate = interface.get_substrate(subtensor_address=self.substrate.url)
+        # self.substrate = interface.get_substrate(subtensor_network=self.network)
+        self.substrate = interface.get_substrate(subtensor_address=self.substrate.url)
         validator_node_id = self.substrate.query(
             "SubtensorModule", "Uids", [self.netuid, self.keypair.ss58_address]
         ).value


### PR DESCRIPTION
The changes in the `neurons/validator.py` file primarily involve updates to the `AgentValidator` class. Here's a summary of the key modifications:

1. **Environment Variables**:
   - Changed `network` and `network_address` from local variables to instance variables (`self.network` and `self.network_address`).

2. **Weight Setting Logic**:
   - Added logic to check the number of blocks since the last weight update and the minimum interval required before setting weights again.
   - Introduced a retry mechanism for setting weights, with up to three attempts and a delay between attempts.

Here's the updated code snippet highlighting the changes:

```python:neurons/validator.py
class AgentValidator:
    ...
    def __init__(self):
        ...
        # Get network configuration from environment
        self.network = os.getenv("SUBTENSOR_NETWORK", "finney")
        self.network_address = os.getenv("SUBTENSOR_ADDRESS")

        self.substrate = interface.get_substrate(
            subtensor_network=self.network, subtensor_address=self.network_address
        )
        ...
    ...
    async def set_weights(self):
        ...
        blocks_since_update = weights._blocks_since_last_update(
            self.substrate, self.netuid, validator_node_id
        )
        min_interval = weights._min_interval_to_set_weights(self.substrate, self.netuid)

        logger.info(f"Blocks since last update: {blocks_since_update}")
        logger.info(f"Minimum interval required: {min_interval}")

        if blocks_since_update is not None and blocks_since_update < min_interval:
            wait_blocks = min_interval - blocks_since_update
            logger.info(
                f"Need to wait {wait_blocks} more blocks before setting weights"
            )
            # Assuming ~12 second block time
            wait_seconds = wait_blocks * 12
            logger.info(f"Waiting {wait_seconds} seconds...")
            await asyncio.sleep(wait_seconds)

        uids, scores = self.get_average_score()

        # Set weights with multiple attempts
        for attempt in range(3):
            try:
                success = weights.set_node_weights(
                    substrate=self.substrate,
                    keypair=self.keypair,
                    node_ids=uids,
                    node_weights=scores,
                    netuid=self.netuid,
                    validator_node_id=validator_node_id,
                    version_key=version_key,
                    wait_for_inclusion=True,
                    wait_for_finalization=True,
                )

                if success:
                    logger.info("✅ Successfully set weights!")
                    return
                else:
                    logger.error(f"❌ Failed to set weights on attempt {attempt + 1}")
                    await asyncio.sleep(10)  # Wait between attempts

            except Exception as e:
                logger.error(f"Error on attempt {attempt + 1}: {str(e)}")
                await asyncio.sleep(10)  # Wait between attempts

        logger.error("Failed to set weights after all attempts")
    ...
```

### Explanation:
- **Environment Variables**: The network configuration is now stored as instance variables, which makes it easier to access throughout the class.
- **Weight Setting Logic**: The code now includes checks for the time since the last weight update and waits if necessary. It also retries setting weights up to three times if it fails, with logging to track the process.
