### PR TITLE
fix: fetching posts stability

### DIFF
--- a/validator/posts_getter.py
+++ b/validator/posts_getter.py
@@ -43,3 +43,4 @@ class PostsGetter:
                 return []
         except Exception as e:
             logger.error(f"Exception occurred while fetching posts: {str(e)}")
+            return []

--- a/validator/posts_getter.py
+++ b/validator/posts_getter.py
@@ -16,7 +16,9 @@ class PostsGetter:
         self.api_key = os.getenv("API_KEY", None)
         self.api_url = os.getenv("API_URL", "https://test.protocol-api.masa.ai")
         self.httpx_client = httpx.AsyncClient(
-            base_url=self.api_url, headers={"Authorization": f"Bearer {self.api_key}"}
+            base_url=self.api_url,
+            headers={"Authorization": f"Bearer {self.api_key}"},
+            timeout=120,
         )
 
     async def get(self) -> List[Any]:


### PR DESCRIPTION
The changes made to the `validator/posts_getter.py` file in the current working branch compared to the main branch are as follows:

1. **Timeout Added to HTTP Client:**
   - In the `PostsGetter` class constructor, a `timeout` parameter has been added to the `httpx.AsyncClient` initialization. The timeout is set to 120 seconds.
   ```python
   self.httpx_client = httpx.AsyncClient(
       base_url=self.api_url,
       headers={"Authorization": f"Bearer {self.api_key}"},
       timeout=120,
   )
   ```

2. **Return Statement Added in Exception Handling:**
   - In the `fetch_posts_from_api` method, a `return []` statement has been added at the end of the exception handling block. This ensures that an empty list is returned if an exception occurs while fetching posts.
   ```python
   except Exception as e:
       logger.error(f"Exception occurred while fetching posts: {str(e)}")
       return []
   ```

These changes improve the robustness of the `PostsGetter` class by setting a timeout for HTTP requests and ensuring that an empty list is returned in case of an error, preventing potential issues with unhandled exceptions.